### PR TITLE
ci: use GitHub App token for PR title check comments

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -46,18 +46,27 @@ jobs:
             echo "valid=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+
       - name: Find existing comment
         uses: peter-evans/find-comment@v3
         id: find-comment
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
+          comment-author: '${{ steps.generate-token.outputs.app-slug }}[bot]'
           body-includes: '<!-- pr-title-check -->'
 
       - name: Comment on valid PR title (will release)
         if: steps.check.outputs.valid == 'true' && steps.check.outputs.release_type != 'none'
         uses: peter-evans/create-or-update-comment@v4
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
@@ -77,6 +86,7 @@ jobs:
         if: steps.check.outputs.valid == 'true' && steps.check.outputs.release_type == 'none'
         uses: peter-evans/create-or-update-comment@v4
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
@@ -96,6 +106,7 @@ jobs:
         if: steps.check.outputs.valid == 'false'
         uses: peter-evans/create-or-update-comment@v4
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |


### PR DESCRIPTION
## Summary
- Switches the PR title check workflow from the default `GITHUB_TOKEN` to a GitHub App token (generated via `actions/create-github-app-token@v2`), matching the approach used in the release workflow.
- Passes the app token to all `peter-evans/find-comment` and `peter-evans/create-or-update-comment` steps.
- Updates the `comment-author` filter to dynamically use the app's bot username instead of the hardcoded `github-actions[bot]`.

## Test plan
- [ ] Open or edit a PR and verify the title check workflow runs successfully
- [ ] Confirm the comment is posted by the GitHub App bot user
- [ ] Verify that subsequent title edits update the existing comment (rather than creating duplicates)

Made with [Cursor](https://cursor.com)