### PR TITLE
fix: add OVSX_PAT to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,5 +54,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
           GIT_AUTHOR_NAME: github-actions[bot]
         run: yarn semantic-release


### PR DESCRIPTION
Adds the `OVSX_PAT` secret to the `semantic-release` step in the release workflow so the extension can be published to the Open VSX Registry.

Using the fix flag so a release is forced